### PR TITLE
Add DeepDOCVN Vietnamese PDF parser option

### DIFF
--- a/api/db/services/task_service.py
+++ b/api/db/services/task_service.py
@@ -367,7 +367,7 @@ def queue_tasks(doc: dict, bucket: str, name: str, priority: int):
         page_size = doc["parser_config"].get("task_page_size") or 12
         if doc["parser_id"] == "paper":
             page_size = doc["parser_config"].get("task_page_size") or 22
-        if doc["parser_id"] in ["one", "knowledge_graph"] or do_layout != "DeepDOC" or doc["parser_config"].get("toc_extraction", False):
+        if doc["parser_id"] in ["one", "knowledge_graph"] or do_layout not in {"DeepDOC", "DeepDOCVN"} or doc["parser_config"].get("toc_extraction", False):
             page_size = 10 ** 9
         page_ranges = doc["parser_config"].get("pages") or [(1, 10 ** 5)]
         for s, e in page_ranges:

--- a/deepdoc/parser/__init__.py
+++ b/deepdoc/parser/__init__.py
@@ -21,6 +21,7 @@ from .json_parser import RAGFlowJsonParser as JsonParser
 from .markdown_parser import MarkdownElementExtractor
 from .markdown_parser import RAGFlowMarkdownParser as MarkdownParser
 from .pdf_parser import PlainParser
+from .pdf_parser import PdfParserVietnamese
 from .pdf_parser import RAGFlowPdfParser as PdfParser
 from .ppt_parser import RAGFlowPptParser as PptParser
 from .txt_parser import RAGFlowTxtParser as TxtParser
@@ -36,5 +37,6 @@ __all__ = [
     "MarkdownParser",
     "TxtParser",
     "MarkdownElementExtractor",
+    "PdfParserVietnamese",
 ]
 

--- a/web/src/components/layout-recognize-form-field.tsx
+++ b/web/src/components/layout-recognize-form-field.tsx
@@ -16,6 +16,7 @@ import {
 
 export const enum ParseDocumentType {
   DeepDOC = 'DeepDOC',
+  DeepDOCVN = 'DeepDOCVN',
   PlainText = 'Plain Text',
   MinerU = 'MinerU',
   Docling = 'Docling',
@@ -43,12 +44,20 @@ export function LayoutRecognizeFormField({
       ? optionsWithoutLLM
       : [
           ParseDocumentType.DeepDOC,
+          ParseDocumentType.DeepDOCVN,
           ParseDocumentType.PlainText,
           ParseDocumentType.MinerU,
           ParseDocumentType.Docling,
           ParseDocumentType.TCADPParser,
         ].map((x) => ({
-          label: x === ParseDocumentType.PlainText ? t(camelCase(x)) : x,
+          label:
+            x === ParseDocumentType.PlainText
+              ? t(camelCase(x))
+              : x === ParseDocumentType.DeepDOC
+                ? x
+                : x === ParseDocumentType.DeepDOCVN
+                  ? 'DeepDOC Vietnamese'
+                  : x,
           value: x,
         }));
 

--- a/web/src/components/layout-recognize.tsx
+++ b/web/src/components/layout-recognize.tsx
@@ -7,6 +7,7 @@ import { useMemo } from 'react';
 
 const enum DocumentType {
   DeepDOC = 'DeepDOC',
+  DeepDOCVN = 'DeepDOCVN',
   PlainText = 'Plain Text',
 }
 
@@ -15,8 +16,13 @@ const LayoutRecognize = () => {
   const allOptions = useSelectLlmOptionsByModelType();
 
   const options = useMemo(() => {
-    const list = [DocumentType.DeepDOC, DocumentType.PlainText].map((x) => ({
-      label: x === DocumentType.PlainText ? t(camelCase(x)) : 'DeepDoc',
+    const list = [DocumentType.DeepDOC, DocumentType.DeepDOCVN, DocumentType.PlainText].map((x) => ({
+      label:
+        x === DocumentType.PlainText
+          ? t(camelCase(x))
+          : x === DocumentType.DeepDOC
+            ? 'DeepDoc'
+            : 'DeepDoc Vietnamese',
       value: x,
     }));
 

--- a/web/src/pages/agent/form/parser-form/pdf-form-fields.tsx
+++ b/web/src/pages/agent/form/parser-form/pdf-form-fields.tsx
@@ -20,6 +20,7 @@ export function PdfFormFields({ prefix }: CommonProps) {
     return (
       !isEmpty(parseMethod) &&
       parseMethod !== ParseDocumentType.DeepDOC &&
+      parseMethod !== ParseDocumentType.DeepDOCVN &&
       parseMethod !== ParseDocumentType.PlainText &&
       parseMethod !== ParseDocumentType.TCADPParser
     );

--- a/web/src/pages/dataset/dataset-setting/index.tsx
+++ b/web/src/pages/dataset/dataset-setting/index.tsx
@@ -27,6 +27,7 @@ import { useFetchKnowledgeConfigurationOnMount } from './hooks';
 import { SavingButton } from './saving-button';
 const enum DocumentType {
   DeepDOC = 'DeepDOC',
+  DeepDOCVN = 'DeepDOCVN',
   PlainText = 'Plain Text',
 }
 


### PR DESCRIPTION
## Summary
- extend the core PDF parser to support configurable alphabet ranges and add `PdfParserVietnamese` for Vietnamese-specific OCR logic
- update PDF ingestion flows (naive, book, manual, paper, one, presentation, QA, laws) to route the new `DeepDOCVN` layout option to the Vietnamese parser and export it for reuse
- expose the `DeepDOCVN` choice across task scheduling and front-end parser configuration UI

## Testing
- python -m compileall deepdoc/parser
- python -m compileall api/db/services/task_service.py

------
https://chatgpt.com/codex/tasks/task_b_690afe79aeec832b8bbefad8dd52bd33