### PR TITLE
Add Vietnamese annotation guidance to prompts

### DIFF
--- a/rag/prompts/template.py
+++ b/rag/prompts/template.py
@@ -5,6 +5,11 @@ PROMPT_DIR = os.path.dirname(__file__)
 
 _loaded_prompts = {}
 
+_VIETNAMESE_OUTPUT_NOTE = (
+    "Chú thích sử dụng tiếng Việt: Khi phản hồi, hãy thêm một câu chú thích ngắn bằng "
+    "tiếng Việt tóm tắt nội dung trả lời. Phần nội dung chính vẫn phải được viết bằng tiếng Anh."
+)
+
 
 def load_prompt(name: str) -> str:
     if name in _loaded_prompts:
@@ -16,5 +21,8 @@ def load_prompt(name: str) -> str:
 
     with open(path, "r", encoding="utf-8") as f:
         content = f.read().strip()
+        if _VIETNAMESE_OUTPUT_NOTE not in content:
+            content = f"{content}\n\n{_VIETNAMESE_OUTPUT_NOTE}"
+
         _loaded_prompts[name] = content
         return content


### PR DESCRIPTION
## Summary
- append a consistent Vietnamese instruction to each loaded prompt
- ensure prompt loading only adds the instruction once to avoid duplication

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690d8686fab4832b8d2202790a6fc789)